### PR TITLE
Update publish workflow to enable write permissions and add GitHub re…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -64,6 +64,16 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Notes:
 # - Create repository secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/publish.yml` to improve the release process. The main changes enhance permissions and automate the creation of GitHub releases after publishing to PyPI.

**Release process improvements:**

* Changed the `permissions` for the workflow from `contents: read` to `contents: write` to allow creating releases.
* Added a new step to automatically create a GitHub Release after publishing to PyPI, using `softprops/action-gh-release@v2` and attaching all files in `dist/`.…lease step